### PR TITLE
IP-4210: [pydub] 압축 데이터를 읽고 쓸 수 있는 기능 구현

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -1469,10 +1469,6 @@ class AudioSegment:
         data = base64.b64encode(fh.read()).decode("ascii")
         return src.format(base64=data)
 
-    def to_io(self) -> io.BytesIO:
-        stream = io.BytesIO()
-        return self.export(stream, format="raw")
-
 
 def is_gzip(file: IO[bytes]) -> bool:
     file.seek(0)

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -11,7 +11,7 @@ import sys
 import wave
 from collections import namedtuple
 from tempfile import NamedTemporaryFile
-from typing import IO
+from typing import IO, Literal
 
 from .exceptions import (
     CouldntDecodeError,
@@ -845,6 +845,34 @@ class AudioSegment:
         return obj
 
     def export(
+        self,
+        out_f: str | os.PathLike | None = None,
+        format: str = "mp3",
+        codec: str | None = None,
+        bitrate: str | None = None,
+        parameters: list[str] | None = None,
+        tags: dict[str, str] | None = None,
+        id3v2_version: str = "4",
+        cover: str | None = None,
+        compressor: Literal["gzip"] | None = None,
+    ) -> IO[bytes]:
+        compressors = {"gzip": gzip.compress}
+
+        result = self._export(
+            out_f=out_f,
+            format=format,
+            codec=codec,
+            bitrate=bitrate,
+            parameters=parameters,
+            tags=tags,
+            id3v2_version=id3v2_version,
+            cover=cover,
+        )
+        if compressor is not None:
+            result = io.BytesIO(compressors[compressor](result.read()))
+        return result
+
+    def _export(
         self,
         out_f=None,
         format="mp3",


### PR DESCRIPTION
## 목적
- 압축 데이터를 읽고 쓸 수 있는 기능 구현

## 변경 사항
- `AudioSegment.export()`
  - `compressor` 인자 추가. 현재는 `gzip`만 허용
- `AudioSegment.from_file()`
  - gzip 파일을 읽을 수 있는 기능 추가
  - 파일이 gzip인지 검사한 후 gzip 형식이면 압축을 해제하고 오디오 로드
- 올바르게 동작하지 않는 `AudioSegment.to_io()` 메서드 제거