### PR TITLE
IP-5787: [pydub] 불필요한 Python 호환성 로직 제거

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -171,10 +171,7 @@ class AudioSegment:
         audio_params = (self.sample_width, self.frame_rate, self.channels)
 
         if isinstance(data, array.array):
-            try:
-                data = data.tobytes()
-            except AttributeError:
-                data = data.tostring()
+            data = data.tobytes()
 
         # prevent partial specification of arguments
         if any(audio_params) and None in audio_params:
@@ -381,10 +378,7 @@ class AudioSegment:
             data = b"".join(data)
 
         if isinstance(data, array.array):
-            try:
-                data = data.tobytes()
-            except:  # noqa: E722
-                data = data.tostring()
+            data = data.tobytes()
 
         # accept file-like objects
         if hasattr(data, "read"):
@@ -398,7 +392,7 @@ class AudioSegment:
             "frame_width": self.frame_width,
             "channels": self.channels,
         }
-        metadata.update(overrides)
+        metadata.update(overrides or {})
         return self.__class__(data=data, metadata=metadata)
 
     @classmethod
@@ -1149,12 +1143,7 @@ class AudioSegment:
         mono_channels = []
         for i in range(self.channels):
             samples_for_current_channel = samples[i :: self.channels]
-
-            try:
-                mono_data = samples_for_current_channel.tobytes()
-            except AttributeError:
-                mono_data = samples_for_current_channel.tostring()
-
+            mono_data = samples_for_current_channel.tobytes()
             mono_channels.append(
                 self._spawn(mono_data, overrides={"channels": 1, "frame_width": self.sample_width})
             )

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -11,7 +11,7 @@ import sys
 import wave
 from collections import namedtuple
 from tempfile import NamedTemporaryFile
-from typing import IO, Literal, Unpack
+from typing import IO, Any, Literal, Self, Unpack
 
 from . import _meter
 from .exceptions import (
@@ -163,7 +163,7 @@ class AudioSegment:
 
     DEFAULT_CODECS = {"ogg": "libvorbis"}
 
-    def __init__(self, data=None, *args, **kwargs):
+    def __init__(self, data: bytes | array.array | io.BytesIO, *args, **kwargs):
         self.sample_width = kwargs.pop("sample_width", None)
         self.frame_rate = kwargs.pop("frame_rate", None)
         self.channels = kwargs.pop("channels", None)
@@ -366,7 +366,7 @@ class AudioSegment:
     def __deepcopy__(self, memo: dict[int, object]) -> AudioSegment:
         return self._spawn(self._data)
 
-    def _spawn(self, data, overrides={}):
+    def _spawn(self, data, overrides: dict[str, Any] | None = None) -> Self:
         """
         Creates a new audio segment using the metadata from the current one
         and the data passed in. Should be used whenever an AudioSegment is

--- a/pydub/generators.py
+++ b/pydub/generators.py
@@ -1,24 +1,19 @@
 """
-Each generator will return float samples from -1.0 to 1.0, which can be 
+Each generator will return float samples from -1.0 to 1.0, which can be
 converted to actual audio with 8, 16, 24, or 32 bit depth using the
 SiganlGenerator.to_audio_segment() method (on any of it's subclasses).
 
-See Wikipedia's "waveform" page for info on some of the generators included 
+See Wikipedia's "waveform" page for info on some of the generators included
 here: http://en.wikipedia.org/wiki/Waveform
 """
 
-import math
 import array
 import itertools
+import math
 import random
-from .audio_segment import AudioSegment
-from .utils import (
-    db_to_float,
-    get_frame_width,
-    get_array_type,
-    get_min_max_value
-)
 
+from .audio_segment import AudioSegment
+from .utils import db_to_float, get_array_type, get_frame_width, get_min_max_value
 
 
 class SignalGenerator(object):
@@ -43,23 +38,22 @@ class SignalGenerator(object):
         sample_data = (int(val * maxval * gain) for val in self.generate())
         sample_data = itertools.islice(sample_data, 0, sample_count)
 
-        data = array.array(array_type, sample_data)
-        
-        try:
-            data = data.tobytes()
-        except:
-            data = data.tostring()
+        data = array.array(array_type, sample_data).tobytes()
 
-        return AudioSegment(data=data, metadata={
-            "channels": 1,
-            "sample_width": sample_width,
-            "frame_rate": self.sample_rate,
-            "frame_width": sample_width,
-        })
+        return AudioSegment(
+            data=data,
+            metadata={
+                "channels": 1,
+                "sample_width": sample_width,
+                "frame_rate": self.sample_rate,
+                "frame_width": sample_width,
+            },
+        )
 
     def generate(self):
-        raise NotImplementedError("SignalGenerator subclasses must implement the generate() method, and *should not* call the superclass implementation.")
-
+        raise NotImplementedError(
+            "SignalGenerator subclasses must implement the generate() method, and *should not* call the superclass implementation."
+        )
 
 
 class Sine(SignalGenerator):
@@ -73,7 +67,6 @@ class Sine(SignalGenerator):
         while True:
             yield math.sin(sine_of * sample_n)
             sample_n += 1
-
 
 
 class Pulse(SignalGenerator):
@@ -97,12 +90,10 @@ class Pulse(SignalGenerator):
             sample_n += 1
 
 
-
 class Square(Pulse):
     def __init__(self, freq, **kwargs):
-        kwargs['duty_cycle'] = 0.5
+        kwargs["duty_cycle"] = 0.5
         super(Square, self).__init__(freq, **kwargs)
-
 
 
 class Sawtooth(SignalGenerator):
@@ -129,10 +120,9 @@ class Sawtooth(SignalGenerator):
             sample_n += 1
 
 
-
 class Triangle(Sawtooth):
     def __init__(self, freq, **kwargs):
-        kwargs['duty_cycle'] = 0.5
+        kwargs["duty_cycle"] = 0.5
         super(Triangle, self).__init__(freq, **kwargs)
 
 


### PR DESCRIPTION
## 목적
- 불필요한 Python 호환성 로직을 제거하여 유지보수성 개선

## 변경 사항
- `array.array().tostring()` 메서드 호출 제거
- 타입 힌트 개선

## TODO (Optional)


## Followers (Optional)
- 해당 PR을 인지하고 있어야 할 팀원을 태그해주세요.