### PR TITLE
IP-5919: [pydub] 파형 표현에 필요한 값을 계산하는 기능 구현

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -1471,6 +1471,18 @@ class AudioSegment:
         }
         return {name: meter_to_measurer[name](self) for name in names}
 
+    def get_normalized_amplitudes(self, num_segments: int) -> list[float]:
+        if not self.rms:
+            raise ValueError("Audio contains no audio data")
+
+        segment_duration = len(self) / num_segments
+        amplitudes = [
+            self[(i * segment_duration) : ((i + 1) * segment_duration)].rms
+            for i in range(num_segments)
+        ]
+        max_amplitude = max(amplitudes)
+        return [(amplitude / max_amplitude) for amplitude in amplitudes]
+
 
 def is_gzip(file: IO[bytes]) -> bool:
     file.seek(0)


### PR DESCRIPTION
## 목적
- 파형 계산에 필요한 값을 계산하는 기능 구현

## 변경 사항
- `AudioSegment.get_normalized_amplitudes()` 메서드 구현

## TODO (Optional)


## Followers (Optional)
- 해당 PR을 인지하고 있어야 할 팀원을 태그해주세요.