### PR TITLE
IP-6443: [pydub] AudioSegment.fade() 메모리 최적화

### DIFF
--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -1404,10 +1404,10 @@ class AudioSegment:
 
         return self._spawn(data=output)
 
-    def fade_out(self, duration):
-        return self.fade(to_gain=-120, duration=duration, end=float("inf"))
+    def fade_out(self, duration: int) -> Self:
+        return self.fade(to_gain=-120, duration=duration, end=len(self))
 
-    def fade_in(self, duration):
+    def fade_in(self, duration: int) -> Self:
         return self.fade(from_gain=-120, duration=duration, start=0)
 
     def reverse(self):


### PR DESCRIPTION
## 목적
- `AudioSegment.fade()` 메모리 최적화

## 변경 사항
- fade 대상이 아닌 데이터 슬라이싱 시 `memoryview`를 사용해 데이터 복사 방지
  - fade 전후 슬라이싱 시 발생하는 2번의 데이터 복사 제거

## TODO (Optional)


## Followers (Optional)
- 해당 PR을 인지하고 있어야 할 팀원을 태그해주세요.