### PR TITLE
IP-7110: [pydub] sample_width 매직 넘버를 IntEnum으로 통합

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,8 @@
 uv run pytest ...
 ```
 
-- 신규 테스트는 pytest 함수형으로 작성 (`test/test.py`는 업스트림 레거시 unittest이므로 예외)
+- 신규 테스트는 반드시 pytest 함수형으로 작성 (클래스 기반 테스트 금지)
+- `test/test.py`는 업스트림 레거시 unittest이므로 예외
 
 ## 에러 메시지
 

--- a/pydub/audio_segment.py
+++ b/pydub/audio_segment.py
@@ -18,6 +18,7 @@ from typing import IO, Any, Literal, Self, TypedDict, Unpack, overload
 
 from . import _compression, _meter, _pydub_core, _wav
 from ._subprocess import _ConversionCommand, _PopenParams
+from .enums import SampleWidth
 from .exceptions import (
     CouldntDecodeError,
     CouldntEncodeError,
@@ -28,7 +29,6 @@ from .exceptions import (
 from .logging_utils import log_conversion, log_subprocess_output
 from .utils import (
     db_to_float,
-    get_array_type,
     get_encoder_name,
     mediainfo_json,
     ratio_to_db,
@@ -152,7 +152,7 @@ class AudioSegment:
         else:
             self._init_with_data(data)
 
-        if self.sample_width == 3:
+        if self.sample_width == SampleWidth.PCM24:
             self._extend_24bit_to_32bit()
 
     def _init_with_audio_params(self, data: bytes, audio_params: _AudioParams) -> None:
@@ -173,23 +173,23 @@ class AudioSegment:
         wav_data = _wav.read_audio(data)
 
         self.channels = wav_data.channels
-        self.sample_width = wav_data.bits_per_sample // 8
+        self.sample_width = SampleWidth.from_bit_depth(wav_data.bits_per_sample)
         self.frame_rate = wav_data.sample_rate
         self._data = wav_data.raw_data
-        if self.sample_width == 1:
+        if self.sample_width == SampleWidth.PCM8:
             # convert from unsigned integers in wav
             self._data = audioop.bias(self._data, 1, -128)
 
     def _extend_24bit_to_32bit(self) -> None:
-        if self.sample_width != 3:
+        if self.sample_width != SampleWidth.PCM24:
             return
 
         self._data = _pydub_core.extend_24bit_to_32bit(self._data)
-        self.sample_width = 4
+        self.sample_width = SampleWidth.PCM32
 
     @classmethod
     def empty(cls) -> Self:
-        return cls(b"", sample_width=1, frame_rate=1, channels=1)
+        return cls(b"", sample_width=SampleWidth.PCM8, frame_rate=1, channels=1)
 
     @classmethod
     def silent(cls, duration: int = 1000, frame_rate: int = 11025) -> Self:
@@ -199,7 +199,7 @@ class AudioSegment:
         """
         frames = int(frame_rate * (duration / 1000.0))
         data = b"\0\0" * frames
-        return cls(data, sample_width=2, frame_rate=frame_rate, channels=1)
+        return cls(data, sample_width=SampleWidth.PCM16, frame_rate=frame_rate, channels=1)
 
     @classmethod
     def from_mono_audiosegments(cls, *mono_segments: Self) -> Self:
@@ -564,7 +564,7 @@ class AudioSegment:
 
     @property
     def array_type(self) -> str:
-        return get_array_type(self.sample_width * 8)
+        return SampleWidth(self.sample_width).array_type
 
     @property
     def rms(self) -> int:
@@ -583,7 +583,7 @@ class AudioSegment:
 
     @property
     def max_possible_amplitude(self) -> float:
-        bits = self.sample_width * 8
+        bits = SampleWidth(self.sample_width).bit_depth
         max_possible_val = 2**bits
 
         # since half is above 0 and half is below the max amplitude is divided
@@ -1026,7 +1026,7 @@ class AudioSegment:
 
     def _write_wav(self, out_f: IO[bytes]) -> None:
         pcm_for_wav = self._data
-        if self.sample_width == 1:
+        if self.sample_width == SampleWidth.PCM8:
             pcm_for_wav = audioop.bias(self._data, 1, 128)
 
         wave_data = wave.open(out_f, "wb")

--- a/pydub/enums.py
+++ b/pydub/enums.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import enum
+
+
+class SampleWidth(enum.IntEnum):
+    PCM8 = 1
+    PCM16 = 2
+    PCM24 = 3
+    PCM32 = 4
+
+    @classmethod
+    def from_bit_depth(cls, bits: int) -> SampleWidth:
+        return cls(bits // 8)
+
+    @property
+    def bit_depth(self) -> int:
+        return self.value * 8
+
+    @property
+    def array_type(self) -> str:
+        _ARRAY_TYPES = {1: "b", 2: "h", 4: "i"}
+        if self.value not in _ARRAY_TYPES:
+            raise ValueError(f"Array type is not available for {self.name} (24-bit)")
+        return _ARRAY_TYPES[self.value]
+
+    @property
+    def value_range(self) -> tuple[int, int]:
+        if self == SampleWidth.PCM24:
+            raise ValueError(f"Value range is not available for {self.name} (24-bit)")
+        bits = self.bit_depth
+        return -(1 << (bits - 1)), (1 << (bits - 1)) - 1

--- a/pydub/enums.py
+++ b/pydub/enums.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import enum
 
+_ARRAY_TYPES = {1: "b", 2: "h", 4: "i"}
+
 
 class SampleWidth(enum.IntEnum):
     PCM8 = 1
@@ -19,14 +21,13 @@ class SampleWidth(enum.IntEnum):
 
     @property
     def array_type(self) -> str:
-        _ARRAY_TYPES = {1: "b", 2: "h", 4: "i"}
         if self.value not in _ARRAY_TYPES:
-            raise ValueError(f"Array type is not available for {self.name} (24-bit)")
+            raise ValueError("'array_type' is not available for 24-bit sample width")
         return _ARRAY_TYPES[self.value]
 
     @property
     def value_range(self) -> tuple[int, int]:
         if self == SampleWidth.PCM24:
-            raise ValueError(f"Value range is not available for {self.name} (24-bit)")
+            raise ValueError("'value_range' is not available for 24-bit sample width")
         bits = self.bit_depth
         return -(1 << (bits - 1)), (1 << (bits - 1)) - 1

--- a/pydub/generators.py
+++ b/pydub/generators.py
@@ -13,7 +13,8 @@ import math
 import random
 
 from .audio_segment import AudioSegment
-from .utils import db_to_float, get_array_type, get_frame_width, get_min_max_value
+from .enums import SampleWidth
+from .utils import db_to_float
 
 
 class SignalGenerator(object):
@@ -28,9 +29,9 @@ class SignalGenerator(object):
         Volume in DB relative to maximum amplitude
             (default 0.0 dBFS, which is the maximum value)
         """
-        minval, maxval = get_min_max_value(self.bit_depth)
-        sample_width = get_frame_width(self.bit_depth)
-        array_type = get_array_type(self.bit_depth)
+        sw = SampleWidth.from_bit_depth(self.bit_depth)
+        minval, maxval = sw.value_range
+        array_type = sw.array_type
 
         gain = db_to_float(volume)
         sample_count = int(self.sample_rate * (duration / 1000.0))
@@ -42,7 +43,7 @@ class SignalGenerator(object):
 
         return AudioSegment(
             data=data,
-            sample_width=sample_width,
+            sample_width=sw,
             frame_rate=self.sample_rate,
             channels=1,
         )

--- a/pydub/utils.py
+++ b/pydub/utils.py
@@ -9,37 +9,6 @@ import subprocess
 import sys
 import warnings
 
-FRAME_WIDTHS = {
-    8: 1,
-    16: 2,
-    32: 4,
-}
-ARRAY_TYPES = {
-    8: "b",
-    16: "h",
-    32: "i",
-}
-ARRAY_RANGES = {
-    8: (-0x80, 0x7F),
-    16: (-0x8000, 0x7FFF),
-    32: (-0x80000000, 0x7FFFFFFF),
-}
-
-
-def get_frame_width(bit_depth):
-    return FRAME_WIDTHS[bit_depth]
-
-
-def get_array_type(bit_depth, signed=True):
-    t = ARRAY_TYPES[bit_depth]
-    if not signed:
-        t = t.upper()
-    return t
-
-
-def get_min_max_value(bit_depth):
-    return ARRAY_RANGES[bit_depth]
-
 
 def db_to_float(db, using_amplitude=True):
     """

--- a/test/test_sample_width.py
+++ b/test/test_sample_width.py
@@ -3,67 +3,65 @@ import pytest
 from pydub.enums import SampleWidth
 
 
-class TestFromBitDepth:
-    @pytest.mark.parametrize(
-        "bits, expected",
-        [
-            (8, SampleWidth.PCM8),
-            (16, SampleWidth.PCM16),
-            (24, SampleWidth.PCM24),
-            (32, SampleWidth.PCM32),
-        ],
-    )
-    def test_convert_bit_depth_to_sample_width(self, bits, expected):
-        assert SampleWidth.from_bit_depth(bits) == expected
+@pytest.mark.parametrize(
+    "bits, expected",
+    [
+        (8, SampleWidth.PCM8),
+        (16, SampleWidth.PCM16),
+        (24, SampleWidth.PCM24),
+        (32, SampleWidth.PCM32),
+    ],
+)
+def test_from_bit_depth_convert_bit_depth_to_sample_width(bits, expected):
+    assert SampleWidth.from_bit_depth(bits) == expected
 
 
-class TestBitDepth:
-    @pytest.mark.parametrize(
-        "sw, expected",
-        [
-            (SampleWidth.PCM8, 8),
-            (SampleWidth.PCM16, 16),
-            (SampleWidth.PCM24, 24),
-            (SampleWidth.PCM32, 32),
-        ],
-    )
-    def test_return_bit_depth(self, sw, expected):
-        assert sw.bit_depth == expected
+@pytest.mark.parametrize(
+    "sw, expected",
+    [
+        (SampleWidth.PCM8, 8),
+        (SampleWidth.PCM16, 16),
+        (SampleWidth.PCM24, 24),
+        (SampleWidth.PCM32, 32),
+    ],
+)
+def test_bit_depth_return_bit_depth(sw, expected):
+    assert sw.bit_depth == expected
 
 
-class TestArrayType:
-    @pytest.mark.parametrize(
-        "sw, expected",
-        [(SampleWidth.PCM8, "b"), (SampleWidth.PCM16, "h"), (SampleWidth.PCM32, "i")],
-    )
-    def test_return_array_type(self, sw, expected):
-        assert sw.array_type == expected
-
-    def test_raise_for_pcm24(self):
-        with pytest.raises(ValueError):
-            SampleWidth.PCM24.array_type
+@pytest.mark.parametrize(
+    "sw, expected",
+    [(SampleWidth.PCM8, "b"), (SampleWidth.PCM16, "h"), (SampleWidth.PCM32, "i")],
+)
+def test_array_type_return_array_type(sw, expected):
+    assert sw.array_type == expected
 
 
-class TestValueRange:
-    @pytest.mark.parametrize(
-        "sw, expected",
-        [
-            (SampleWidth.PCM8, (-128, 127)),
-            (SampleWidth.PCM16, (-32768, 32767)),
-            (SampleWidth.PCM32, (-2147483648, 2147483647)),
-        ],
-    )
-    def test_return_value_range(self, sw, expected):
-        assert sw.value_range == expected
-
-    def test_raise_for_pcm24(self):
-        with pytest.raises(ValueError):
-            SampleWidth.PCM24.value_range
+def test_array_type_raise_for_pcm24():
+    with pytest.raises(ValueError):
+        SampleWidth.PCM24.array_type
 
 
-class TestIntEnumCompatibility:
-    def test_is_instance_of_int(self):
-        assert isinstance(SampleWidth.PCM16, int)
+@pytest.mark.parametrize(
+    "sw, expected",
+    [
+        (SampleWidth.PCM8, (-128, 127)),
+        (SampleWidth.PCM16, (-32768, 32767)),
+        (SampleWidth.PCM32, (-2147483648, 2147483647)),
+    ],
+)
+def test_value_range_return_value_range(sw, expected):
+    assert sw.value_range == expected
 
-    def test_equal_to_int_literal(self):
-        assert SampleWidth.PCM16 == 2
+
+def test_value_range_raise_for_pcm24():
+    with pytest.raises(ValueError):
+        SampleWidth.PCM24.value_range
+
+
+def test_int_enum_is_instance_of_int():
+    assert isinstance(SampleWidth.PCM16, int)
+
+
+def test_int_enum_equal_to_int_literal():
+    assert SampleWidth.PCM16 == 2

--- a/test/test_sample_width.py
+++ b/test/test_sample_width.py
@@ -12,7 +12,7 @@ from pydub.enums import SampleWidth
         (32, SampleWidth.PCM32),
     ],
 )
-def test_from_bit_depth_convert_bit_depth_to_sample_width(bits, expected):
+def test_from_bit_depth_resolve_bit_depth_to_matching_member(bits, expected):
     assert SampleWidth.from_bit_depth(bits) == expected
 
 
@@ -25,7 +25,7 @@ def test_from_bit_depth_convert_bit_depth_to_sample_width(bits, expected):
         (SampleWidth.PCM32, 32),
     ],
 )
-def test_bit_depth_return_bit_depth(sw, expected):
+def test_bit_depth_reverse_byte_to_bit_conversion(sw, expected):
     assert sw.bit_depth == expected
 
 
@@ -33,11 +33,11 @@ def test_bit_depth_return_bit_depth(sw, expected):
     "sw, expected",
     [(SampleWidth.PCM8, "b"), (SampleWidth.PCM16, "h"), (SampleWidth.PCM32, "i")],
 )
-def test_array_type_return_array_type(sw, expected):
+def test_array_type_map_to_python_array_typecode(sw, expected):
     assert sw.array_type == expected
 
 
-def test_array_type_raise_for_pcm24():
+def test_array_type_reject_pcm24_without_array_representation():
     with pytest.raises(ValueError):
         SampleWidth.PCM24.array_type
 
@@ -50,18 +50,10 @@ def test_array_type_raise_for_pcm24():
         (SampleWidth.PCM32, (-2147483648, 2147483647)),
     ],
 )
-def test_value_range_return_value_range(sw, expected):
+def test_value_range_return_signed_integer_bounds(sw, expected):
     assert sw.value_range == expected
 
 
-def test_value_range_raise_for_pcm24():
+def test_value_range_reject_pcm24_without_array_representation():
     with pytest.raises(ValueError):
         SampleWidth.PCM24.value_range
-
-
-def test_int_enum_is_instance_of_int():
-    assert isinstance(SampleWidth.PCM16, int)
-
-
-def test_int_enum_equal_to_int_literal():
-    assert SampleWidth.PCM16 == 2

--- a/test/test_sample_width.py
+++ b/test/test_sample_width.py
@@ -1,0 +1,69 @@
+import pytest
+
+from pydub.enums import SampleWidth
+
+
+class TestFromBitDepth:
+    @pytest.mark.parametrize(
+        "bits, expected",
+        [
+            (8, SampleWidth.PCM8),
+            (16, SampleWidth.PCM16),
+            (24, SampleWidth.PCM24),
+            (32, SampleWidth.PCM32),
+        ],
+    )
+    def test_convert_bit_depth_to_sample_width(self, bits, expected):
+        assert SampleWidth.from_bit_depth(bits) == expected
+
+
+class TestBitDepth:
+    @pytest.mark.parametrize(
+        "sw, expected",
+        [
+            (SampleWidth.PCM8, 8),
+            (SampleWidth.PCM16, 16),
+            (SampleWidth.PCM24, 24),
+            (SampleWidth.PCM32, 32),
+        ],
+    )
+    def test_return_bit_depth(self, sw, expected):
+        assert sw.bit_depth == expected
+
+
+class TestArrayType:
+    @pytest.mark.parametrize(
+        "sw, expected",
+        [(SampleWidth.PCM8, "b"), (SampleWidth.PCM16, "h"), (SampleWidth.PCM32, "i")],
+    )
+    def test_return_array_type(self, sw, expected):
+        assert sw.array_type == expected
+
+    def test_raise_for_pcm24(self):
+        with pytest.raises(ValueError):
+            SampleWidth.PCM24.array_type
+
+
+class TestValueRange:
+    @pytest.mark.parametrize(
+        "sw, expected",
+        [
+            (SampleWidth.PCM8, (-128, 127)),
+            (SampleWidth.PCM16, (-32768, 32767)),
+            (SampleWidth.PCM32, (-2147483648, 2147483647)),
+        ],
+    )
+    def test_return_value_range(self, sw, expected):
+        assert sw.value_range == expected
+
+    def test_raise_for_pcm24(self):
+        with pytest.raises(ValueError):
+            SampleWidth.PCM24.value_range
+
+
+class TestIntEnumCompatibility:
+    def test_is_instance_of_int(self):
+        assert isinstance(SampleWidth.PCM16, int)
+
+    def test_equal_to_int_literal(self):
+        assert SampleWidth.PCM16 == 2

--- a/test/test_sample_width.py
+++ b/test/test_sample_width.py
@@ -12,7 +12,7 @@ from pydub.enums import SampleWidth
         (32, SampleWidth.PCM32),
     ],
 )
-def test_from_bit_depth_resolve_bit_depth_to_matching_member(bits, expected):
+def test_from_bit_depth_resolve_bit_depth_to_matching_member(bits: int, expected: SampleWidth):
     assert SampleWidth.from_bit_depth(bits) == expected
 
 
@@ -25,7 +25,7 @@ def test_from_bit_depth_resolve_bit_depth_to_matching_member(bits, expected):
         (SampleWidth.PCM32, 32),
     ],
 )
-def test_bit_depth_reverse_byte_to_bit_conversion(sw, expected):
+def test_bit_depth_reverse_byte_to_bit_conversion(sw: SampleWidth, expected: int):
     assert sw.bit_depth == expected
 
 
@@ -33,7 +33,7 @@ def test_bit_depth_reverse_byte_to_bit_conversion(sw, expected):
     "sw, expected",
     [(SampleWidth.PCM8, "b"), (SampleWidth.PCM16, "h"), (SampleWidth.PCM32, "i")],
 )
-def test_array_type_map_to_python_array_typecode(sw, expected):
+def test_array_type_map_to_python_array_typecode(sw: SampleWidth, expected: str):
     assert sw.array_type == expected
 
 
@@ -50,7 +50,7 @@ def test_array_type_reject_pcm24_without_array_representation():
         (SampleWidth.PCM32, (-2147483648, 2147483647)),
     ],
 )
-def test_value_range_return_signed_integer_bounds(sw, expected):
+def test_value_range_return_signed_integer_bounds(sw: SampleWidth, expected: tuple[int, int]):
     assert sw.value_range == expected
 
 

--- a/test/test_sample_width.py
+++ b/test/test_sample_width.py
@@ -17,7 +17,7 @@ def test_from_bit_depth_resolve_bit_depth_to_matching_member(bits: int, expected
 
 
 @pytest.mark.parametrize(
-    "sw, expected",
+    "sample_width, expected",
     [
         (SampleWidth.PCM8, 8),
         (SampleWidth.PCM16, 16),
@@ -25,16 +25,16 @@ def test_from_bit_depth_resolve_bit_depth_to_matching_member(bits: int, expected
         (SampleWidth.PCM32, 32),
     ],
 )
-def test_bit_depth_reverse_byte_to_bit_conversion(sw: SampleWidth, expected: int):
-    assert sw.bit_depth == expected
+def test_bit_depth_reverse_byte_to_bit_conversion(sample_width: SampleWidth, expected: int):
+    assert sample_width.bit_depth == expected
 
 
 @pytest.mark.parametrize(
-    "sw, expected",
+    "sample_width, expected",
     [(SampleWidth.PCM8, "b"), (SampleWidth.PCM16, "h"), (SampleWidth.PCM32, "i")],
 )
-def test_array_type_map_to_python_array_typecode(sw: SampleWidth, expected: str):
-    assert sw.array_type == expected
+def test_array_type_map_to_python_array_typecode(sample_width: SampleWidth, expected: str):
+    assert sample_width.array_type == expected
 
 
 def test_array_type_reject_pcm24_without_array_representation():
@@ -43,15 +43,17 @@ def test_array_type_reject_pcm24_without_array_representation():
 
 
 @pytest.mark.parametrize(
-    "sw, expected",
+    "sample_width, expected",
     [
         (SampleWidth.PCM8, (-128, 127)),
         (SampleWidth.PCM16, (-32768, 32767)),
         (SampleWidth.PCM32, (-2147483648, 2147483647)),
     ],
 )
-def test_value_range_return_signed_integer_bounds(sw: SampleWidth, expected: tuple[int, int]):
-    assert sw.value_range == expected
+def test_value_range_return_signed_integer_bounds(
+    sample_width: SampleWidth, expected: tuple[int, int]
+):
+    assert sample_width.value_range == expected
 
 
 def test_value_range_reject_pcm24_without_array_representation():


### PR DESCRIPTION
## 목적

audio_segment.py, generators.py에 산재된 sample_width 매직 넘버(1, 2, 3, 4)와 utils.py의 분산된 상수/함수를 SampleWidth IntEnum으로 통합하여 가독성과 응집도를 높임

## 변경 사항

- **SampleWidth IntEnum 추가 (`pydub/enums.py`)**
  - PCM8/PCM16/PCM24/PCM32 멤버와 `from_bit_depth`, `bit_depth`, `array_type`, `value_range` 프로퍼티 제공
- **매직 넘버 치환**
  - audio_segment.py의 sample_width 비교/대입을 SampleWidth enum 멤버로 교체
  - generators.py의 분산된 유틸 함수 호출(`get_frame_width`, `get_array_type`, `get_min_max_value`)을 SampleWidth로 통합
- **utils.py 정리**
  - SampleWidth enum으로 대체된 상수(`FRAME_WIDTHS`, `ARRAY_TYPES`, `ARRAY_RANGES`)와 함수 제거
- **테스트 추가 (`test/test_sample_width.py`)**
  - SampleWidth의 변환, 프로퍼티, 에러 케이스에 대한 함수형 테스트


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **리팩토링**
  * 오디오 샘플 너비 처리 내부 코드 개선으로 일관성 및 유지보수성 강화

* **테스트**
  * 오디오 포맷 처리에 대한 포괄적인 테스트 커버리지 추가

* **문서**
  * 테스트 작성 가이드라인 명확화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->